### PR TITLE
Fix: Displaying same message in two requests

### DIFF
--- a/src/IPub/FlashMessages/FlashNotifier.php
+++ b/src/IPub/FlashMessages/FlashNotifier.php
@@ -267,7 +267,7 @@ class FlashNotifier extends Nette\Object
 	private function checkUnique(Entities\IMessage $flash, array $messages) : bool
 	{
 		foreach ($messages as $member) {
-			if ((string) $member === (string) $flash) {
+			if ((string) $member === (string) $flash && !$member->isDisplayed()) {
 				return TRUE;
 			}
 		}


### PR DESCRIPTION
For example: If the form was submitted two times with same mistake (we want to show same error message two times), message is not displayed after second submit.